### PR TITLE
Encryption adapters

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,21 @@ import ReactDOM from 'react-dom';
 import './index.css';
 import App from './components/App';
 
+import * as trezor from './lib/encryption_adapters/trezor';
+import * as dummy from './lib/encryption_adapters/dummy';
+
 import registerServiceWorker from './registerServiceWorker';
+
+const encryptionAdapters = {
+  dummy: dummy,
+  trezor: trezor
+};
+
+const encryption = encryptionAdapters.trezor;
 
 ReactDOM.render(<App />, document.getElementById('root'));
 registerServiceWorker();
+
+
+// TODO: Just for manual tryouts, remove when in UI
+window.encryption = encryption;

--- a/src/lib/encryption_adapters/dummy.js
+++ b/src/lib/encryption_adapters/dummy.js
@@ -1,0 +1,35 @@
+const marker = ':::ENCRYPTED::: ';
+
+const isValid = message => true;
+
+const encrypt = (message, options = {}) => {
+  const encrypted = marker.concat(message);
+  const promise = new Promise((resolve, reject) => {
+    window.setTimeout(() => {
+      if (options.fakeError) {
+        reject({ error: options.fakeError });
+      } else {
+        resolve({ content: encrypted });
+      }
+    }, 200);
+  });
+
+  return promise;
+};
+
+const decrypt = (message, options = {}) => {
+  const decrypted = message.replace(marker, '');
+  const promise = new Promise((resolve, reject) => {
+    window.setTimeout(() => {
+      if (options.fakeError) {
+        reject({ error: options.fakeError });
+      } else {
+        resolve({ content: decrypted });
+      }
+    }, 200);
+  });
+
+  return promise;
+};
+
+export { isValid, encrypt, decrypt };

--- a/src/lib/encryption_adapters/dummy.js
+++ b/src/lib/encryption_adapters/dummy.js
@@ -1,6 +1,6 @@
 const marker = ':::ENCRYPTED::: ';
 
-const isValid = message => true;
+const isValid = (message) => true;
 
 const encrypt = (message, options = {}) => {
   const encrypted = marker.concat(message);

--- a/src/lib/encryption_adapters/dummy.test.js
+++ b/src/lib/encryption_adapters/dummy.test.js
@@ -1,0 +1,53 @@
+import * as adapter from './dummy.js';
+
+jest.useFakeTimers();
+
+describe('#isValid', () => {
+  it('returns true', () => {
+    expect(adapter.isValid('some message')).toEqual(true);
+  });
+});
+
+describe('#encrypt', () => {
+  it('returns a promise', () => {
+    const message = 'hello world';
+
+    expect.assertions(1);
+    adapter.encrypt(message).then(result => {
+      expect(result.content).toEqual(':::ENCRYPTED::: hello world');
+    });
+    jest.runAllTimers();
+  });
+
+  it('can fake an error', () => {
+    const message = 'hello world';
+
+    expect.assertions(1);
+    adapter.encrypt(message, { fakeError: 'MY ERROR MESSAGE' }).catch(result => {
+      expect(result.error).toEqual('MY ERROR MESSAGE');
+    });
+    jest.runAllTimers();
+  });
+});
+
+describe('#decrypt', () => {
+  it('returns a promise', () => {
+    const message = ':::ENCRYPTED::: hello world';
+
+    expect.assertions(1);
+    adapter.decrypt(message).then(result => {
+      expect(result.content).toEqual('hello world');
+    });
+    jest.runAllTimers();
+  });
+
+  it('can fake an error', () => {
+    const message = 'hello world';
+
+    expect.assertions(1);
+    adapter.decrypt(message, { fakeError: 'MY ERROR MESSAGE' }).catch(result => {
+      expect(result.error).toEqual('MY ERROR MESSAGE');
+    });
+    jest.runAllTimers();
+  });
+});

--- a/src/lib/encryption_adapters/dummy.test.js
+++ b/src/lib/encryption_adapters/dummy.test.js
@@ -13,7 +13,7 @@ describe('#encrypt', () => {
     const message = 'hello world';
 
     expect.assertions(1);
-    adapter.encrypt(message).then(result => {
+    adapter.encrypt(message).then((result) => {
       expect(result.content).toEqual(':::ENCRYPTED::: hello world');
     });
     jest.runAllTimers();
@@ -23,7 +23,7 @@ describe('#encrypt', () => {
     const message = 'hello world';
 
     expect.assertions(1);
-    adapter.encrypt(message, { fakeError: 'MY ERROR MESSAGE' }).catch(result => {
+    adapter.encrypt(message, { fakeError: 'MY ERROR MESSAGE' }).catch((result) => {
       expect(result.error).toEqual('MY ERROR MESSAGE');
     });
     jest.runAllTimers();
@@ -35,7 +35,7 @@ describe('#decrypt', () => {
     const message = ':::ENCRYPTED::: hello world';
 
     expect.assertions(1);
-    adapter.decrypt(message).then(result => {
+    adapter.decrypt(message).then((result) => {
       expect(result.content).toEqual('hello world');
     });
     jest.runAllTimers();
@@ -45,7 +45,7 @@ describe('#decrypt', () => {
     const message = 'hello world';
 
     expect.assertions(1);
-    adapter.decrypt(message, { fakeError: 'MY ERROR MESSAGE' }).catch(result => {
+    adapter.decrypt(message, { fakeError: 'MY ERROR MESSAGE' }).catch((result) => {
       expect(result.error).toEqual('MY ERROR MESSAGE');
     });
     jest.runAllTimers();

--- a/src/lib/encryption_adapters/trezor.js
+++ b/src/lib/encryption_adapters/trezor.js
@@ -1,0 +1,52 @@
+import { normalizeAfterDecryption, prepareForEncryption } from '../hex';
+/*global TrezorConnect*/
+
+const maxLength = 500;
+
+// IMPORTANT:
+// Changing path OR key will change en-/decryption results!!!
+const path = "m/10016'/0";
+const key = 'Unlock KERKER?';
+
+const confirmEncryption = false;
+const confirmDecryption = false;
+
+const isValid = (content = '') => content.length <= maxLength;
+
+const encrypt = (content, options = {}) => {
+  const value = prepareForEncryption(content);
+
+  const trezorCall = (resolve, reject) => {
+    buildTrezorCall({ content: value, encrypt: true }, (result) => {
+      if (result.success) {
+        resolve({ content: result.value });
+      } else {
+        reject({ error: result.error });
+      }
+    });
+  };
+
+  return new Promise(trezorCall);
+};
+
+const decrypt = (content, options = {}) => {
+  const trezorCall = (resolve, reject) => {
+    buildTrezorCall({ content, encrypt: false }, (result) => {
+      if (result.success) {
+        resolve({ content: normalizeAfterDecryption(result.value) });
+      } else {
+        reject({ error: result.error });
+      }
+    });
+  };
+
+  return new Promise(trezorCall);
+};
+
+const buildTrezorCall = ({ content, encrypt }, callback) => {
+  return TrezorConnect.cipherKeyValue(
+    path, key, content, encrypt, confirmEncryption, confirmDecryption, callback
+  );
+};
+
+export { isValid, encrypt, decrypt };

--- a/src/lib/encryption_adapters/trezor.js
+++ b/src/lib/encryption_adapters/trezor.js
@@ -1,5 +1,4 @@
 import { normalizeAfterDecryption, prepareForEncryption } from '../hex';
-/*global TrezorConnect*/
 
 const maxLength = 500;
 
@@ -44,7 +43,7 @@ const decrypt = (content, options = {}) => {
 };
 
 const buildTrezorCall = ({ content, encrypt }, callback) => {
-  return TrezorConnect.cipherKeyValue(
+  return window.TrezorConnect.cipherKeyValue(
     path, key, content, encrypt, confirmEncryption, confirmDecryption, callback
   );
 };

--- a/src/lib/encryption_adapters/trezor.test.js
+++ b/src/lib/encryption_adapters/trezor.test.js
@@ -1,0 +1,117 @@
+import * as adapter from './trezor.js';
+import * as hex from '../hex.js';
+
+let mockEncryptionSuccess = jest.fn((...args) => {
+  const cb = args[args.length - 1];
+  cb({ success: true, value: 'VALUE' });
+});
+
+let mockDecryptionSuccess = jest.fn((...args) => {
+  const cb = args[args.length - 1];
+  // 'hello world' in hex and padded
+  const value = '00680065006c006c006f00200077006f0072006c006400050005000500050005';
+  cb({ success: true, value: value });
+});
+
+let mockFailure = jest.fn((...args) => {
+  const cb = args[args.length - 1];
+  cb({ success: false, error: 'ERROR' });
+});
+
+global.TrezorConnect = {
+  cipherKeyValue: null
+};
+
+const expectedPath = "m/10016'/0";
+const expectedKey = 'Unlock KERKER?';
+const expectedConfirmEncryption = false;
+const expectedConfirmDecryption = false;
+
+describe('#isValid', () => {
+  it('accepts an empty string', () => {
+    const input = '';
+    expect(adapter.isValid(input)).toBe(true);
+  });
+
+  it('accepts a string that is not too long', () => {
+    const input = 'x'.repeat(500);
+    expect(adapter.isValid(input)).toBe(true);
+  });
+
+  it('rejects a string that is too long', () => {
+    const input = 'x'.repeat(501);
+    expect(adapter.isValid(input)).toBe(false);
+  });
+});
+
+describe('#encrypt', () => {
+  describe('successful encryption', () => {
+    beforeEach(() => global.TrezorConnect.cipherKeyValue = mockEncryptionSuccess);
+
+    it('returns a promise that resolves with the result', () => {
+      expect.assertions(1);
+      return expect(adapter.encrypt('PLAIN')).resolves.toEqual({ content: 'VALUE' });
+    });
+
+    it('calls the trezor API with the expected arguments', () => {
+      expect.assertions(7);
+
+      global.TrezorConnect.cipherKeyValue = jest.fn((...args) => {
+        expect(args[0]).toEqual(expectedPath);
+        expect(args[1]).toEqual(expectedKey);
+        expect(args[2]).toEqual(hex.prepareForEncryption('PLAIN'));
+        expect(args[3]).toEqual(true);
+        expect(args[4]).toEqual(expectedConfirmEncryption);
+        expect(args[5]).toEqual(expectedConfirmDecryption);
+        mockEncryptionSuccess.apply(null, args);
+      });
+
+      return expect(adapter.encrypt('PLAIN')).resolves.toEqual({ content: 'VALUE' });
+    });
+  });
+
+  describe('failing encryption', () => {
+    beforeEach(() => global.TrezorConnect.cipherKeyValue = mockFailure);
+
+    it('returns a promise that rejects with an error', () => {
+      expect.assertions(1);
+      return expect(adapter.encrypt('PLAIN')).rejects.toEqual({ error: 'ERROR' });
+    });
+  });
+});
+
+describe('#decrypt', () => {
+  beforeEach(() => global.TrezorConnect.cipherKeyValue = mockDecryptionSuccess);
+
+  describe('successful decryption', () => {
+    it('returns a promise that resolves with the result', () => {
+      expect.assertions(1);
+      return expect(adapter.decrypt('SECRET')).resolves.toEqual({ content: 'hello world' });
+    });
+
+    it('calls the trezor API with the expected arguments', () => {
+      expect.assertions(7);
+
+      global.TrezorConnect.cipherKeyValue = jest.fn((...args) => {
+        expect(args[0]).toEqual(expectedPath);
+        expect(args[1]).toEqual(expectedKey);
+        expect(args[2]).toEqual('SECRET');
+        expect(args[3]).toEqual(false);
+        expect(args[4]).toEqual(expectedConfirmEncryption);
+        expect(args[5]).toEqual(expectedConfirmDecryption);
+        mockDecryptionSuccess.apply(null, args);
+      });
+
+      return expect(adapter.decrypt('SECRET')).resolves.toEqual({ content: 'hello world' });
+    });
+  });
+
+  describe('failing decryption', () => {
+    beforeEach(() => global.TrezorConnect.cipherKeyValue = mockFailure);
+
+    it('returns a promise that rejects with an error', () => {
+      expect.assertions(1);
+      return expect(adapter.encrypt('PLAIN')).rejects.toEqual({ error: 'ERROR' });
+    });
+  });
+});

--- a/src/lib/hex.js
+++ b/src/lib/hex.js
@@ -9,19 +9,19 @@ const paddingLength = 32;
 
 const splitDigitsRegex = new RegExp(`.{1,${hexDigits}}`, 'g');
 
-const numToHex = num => {
+const numToHex = (num) => {
   return num.toString(16).padStart(hexDigits, '0');
 };
 
-const charToHex = char => {
+const charToHex = (char) => {
   return numToHex(char.charCodeAt(0));
 };
 
-const hexToNum = hexStr => {
+const hexToNum = (hexStr) => {
   return parseInt(hexStr, 16);
 };
 
-const hexToChar = hexStr => {
+const hexToChar = (hexStr) => {
   return String.fromCharCode(hexToNum(hexStr));
 };
 

--- a/src/lib/hex.js
+++ b/src/lib/hex.js
@@ -55,7 +55,7 @@ const unpad = (str) => {
   const expectedPadding = addedHex.repeat(addedNum);
 
   if (!str.endsWith(expectedPadding)) {
-    throw 'Padding is not as expected';
+    throw new Error('Padding is not as expected');
   }
 
   return str.substr(0, str.length - addedHexChars);


### PR DESCRIPTION
This PR adds two adapters to be used for encryption.
One uses the Trezor bridge and Trezor connect.
The other one is just a dummy adapter so one can test the application without actually using a Trezor.